### PR TITLE
Fix max-delay on the progressive strategy

### DIFF
--- a/src/perseverance/core.clj
+++ b/src/perseverance/core.clj
@@ -98,7 +98,7 @@
     (when-not (and max-count (> attempt max-count))
       (if (<= attempt stable-length)
         initial-delay
-        (* initial-delay (int (Math/pow multiplier (- attempt stable-length))))))))
+        (min max-delay (* initial-delay (int (Math/pow multiplier (- attempt stable-length)))))))))
 
 (defn- default-log-fn
   "Prints a message to stdout that an error happened and going to be retried."


### PR DESCRIPTION
Fixes issue #3 by taking the min of the max delay and the normally
calculated delay.