### PR TITLE
Fix int range exceeded

### DIFF
--- a/src/perseverance/core.clj
+++ b/src/perseverance/core.clj
@@ -98,8 +98,8 @@
     (when-not (and max-count (> attempt max-count))
       (if (<= attempt stable-length)
         initial-delay
-        (min max-delay
-             (* initial-delay (int (Math/pow multiplier (- attempt stable-length)))))))))
+        (int (min max-delay
+                  (* initial-delay (Math/pow multiplier (- attempt stable-length)))))))))
 
 (defn- default-log-fn
   "Prints a message to stdout that an error happened and going to be retried."

--- a/test/perseverance/t_core.clj
+++ b/test/perseverance/t_core.clj
@@ -37,7 +37,13 @@
          (map (progressive-retry-strategy :initial-delay 1 :stable-length 1
                                           :multiplier 2 :max-delay 1000
                                           :max-count 5)
-              (range 1 11)))))
+              (range 1 11))))
+
+  (is (= [10 10 10 300 300 300 300 300 300 300]
+         (map (progressive-retry-strategy :initial-delay 10 :stable-length 3
+                                          :multiplier 30 :max-delay 300)
+              (range 1 11)))
+      "exceed range for ints"))
 
 (defn make-dial-up []
   (let [state (atom {:good? true, :left 3, :data 1})]


### PR DESCRIPTION
The first commit has a new test that demonstrates exceeding the range for ints.

The second commit has the proposed fix: `int` can't handle positive infinity directly, but `*` and `min` can. And once the value passes through them, then `int` is safe to use.